### PR TITLE
chore: revises

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/understanding-fips/fip-00045.md
+++ b/understanding-fips/fip-00045.md
@@ -149,18 +149,9 @@ SP 激励：
 
 对于生态的考虑:
 
-> - Indefinitely-extended QA power over a long period could allow a provider to accumulate a large amount of consensus power relative to their storage commitment.
->   - This is probably not an issue if many other providers also accumulate power through long-term storage of verified useful data. That’s probably healthy network behaviour.
->   - The verified registry notaries could set a conservative maximum term for data cap allocations to limit term extension until we’re confident the behaviour is healthy.
-> - Data cap is too powerful if indefinite.
->   - Each unit of data cap becomes less powerful with each incremental unit of data cap granted elsewhere. As verification procedures and automation improve, we might expect data cap to become increasingly abundant over time.
->   - Verified registry limits could bound the long-term power initially.
-> - The network might end up carrying a bunch of data that’s not very useful.
->   - In an environment of increasing abundance of storage capacity and/or demand, this should be a relatively minor concern. Eventually the subsidy earned by verified-but-not-useful data will fall below the opportunity cost of a paid-for storage deal; the situation can only last until the market-clearing price for a verified piece of data rises above zero.
->   - Verified registry limits could bound the worst case, as we gain confidence
-> - Longer FIL+ terms reward early participants more than later ones.
->   - This is true, but this reward to being early is usually seen as compensation for the risk of committing to a new network.
->   - Abundant data cap will reward providers that commit to storing useful data even more than those who are early but less aligned.
+- datacap可被续期的最大值还有待实践中，慢慢斟酌；无限制的话，肯定是不行的
+- datacap在f+治理自动化和能力提升后，应该进一步充足；网络估计会有很多没有多大用处的数据
+- 由此，datacap会有一定的早期入局红利
 
 **`FIP45`的影响远不止上述提到的内容, 可以说其对于 filecoin 架构和生态的影响都非常的巨大.其影响会随着时间的推移逐步的体现出来.**
 

--- a/understanding-fips/fip-00045.md
+++ b/understanding-fips/fip-00045.md
@@ -8,9 +8,8 @@
   由`FIL+clients`发出的验证订单, 产生的算力, 是普通数据的 10 倍.
 
 #### 提案概述
-
 伴随`FVM`更开放的可编程性, filecoin 有可能实现延长`FIL+ data cap`分配期限, 意味着存储验证数据的`SP`可能不再受`storage market actor`相关的订单限制,享受更长久的算力和奖励增加.
-此提案, 目的是将 FIL+与`storage market actor`分离, 抽象出新的`data cap actor`, 相关的业务完全由`verified registry actor`和`data cap actor`来接替.
+此提案, 目的是将 FIL+与`storage market actor`分离, 抽象出新的`datacap token`, 相关的业务完全由`verified registry actor`和`datacap token`来接替.
 
 提案依赖:[FIP34](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0034.md), [解读](#FIP34 Fix pre-commit deposit independent of sector content 解读)
 
@@ -38,22 +37,20 @@
 - 通过实现允许`verified deal`的数据,可以从一个 sector 转移到过期时间更久的 sector 上,来解决以上两个问题.
 
 - 伴随[FVM 架构调整](https://github.com/filecoin-project/FIPs/discussions/298), `fvm`提供更加开放的可编程性, 开发者可以开发一种自己的`storage market`替代内置的.
-  `data cap`数据不应该被内置的`storage market`独享, 所以需要从内置`market`中将此部分业务抽象成独立的`data cap actor`
+  `data cap`数据不应该被内置的`storage market`独享, 所以需要从内置`market`中将此部分业务抽象成独立的`datacap token`
 
 #### 预期功能
 
 - 带'data cap'数据配额的分配将和数据本身以及`SP`相关, 而不是订单.
-- 带'data cap'数据有一个与 sector 的承诺期限无关的期限的上下限.
+- 带'data cap'数据有一个与 sector 的承诺期限无关的期限的周期区间.
 - `SP`只需要在一个生命周期大于`verified data`最小生命周期, 小于或等于其最大周期的 sector 中证明了其存储就可以立刻得到增强算力和奖励.
-  当 sector 过期后,`SP`可以在其新的 sector 中承诺这部分数据.一直到`data cap`过期.
+  当 sector 过期后,`SP`可以在其新的 sector 中继续承诺这部分数据.一直到`data cap`过期.
 - 存储客户和`SP`之间可以不走`storage market`的订单流程(直接将验证数据`add piece`到 sector 中?)
 - 公证人可以通过机制控制验证客户发出`verified data`的最大期限
 - 计算`QA power`的方法被简化
 
 **思考:**
 为什么 sector 的周期必须小于或等于`verified data`的最大期限?
-**待研究:**
-当`price`为 0 时, 不通过`storage market`如何进行存储业务?
 
 #### 技术解读
 
@@ -61,29 +58,60 @@
 <!-- - Allocation: `FIL+ clients`将其下验证数据配额分配到某个数据上. -->
 <!-- - Claim: `SP`申明其存储了某个`Allocation`的部分或者所有数据. -->
 
-- `builtin-actor`增加`data cap actor`, 关于`FIL+`相关的业务完全由新增加的`data cap actor`和升级后的`verified registry actor`来承接.
-- `miner actor` 改动
+- `builtin-actor`增加`datacap token`, 关于`FIL+`相关的业务完全由新增加的`datacap token`和升级后的`verified registry actor`来承接.
+
+- `miner actor` 改动:(**疑惑**:[fip](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0045.md#simplified-quality-adjusted-power)中的描述和[实现](https://github.com/filecoin-project/builtin-actors/blob/cf557e82939844ee8e1d5839bb7f2cbdd50e58ae/actors/miner/src/lib.rs#L3799-L3801)没对上, 尚待完成?)
 
   - `QA power`计算变化为: `SectorSize + (9 * VerifedDealWeight)`
-  - `DealWeight` 和 `VerifiedDealWeight`的直接等于`SectorSize`(**疑惑**:[fip](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0045.md#simplified-quality-adjusted-power)中的描述和[实现](https://github.com/filecoin-project/builtin-actors/blob/cf557e82939844ee8e1d5839bb7f2cbdd50e58ae/actors/miner/src/lib.rs#L3799-L3801)没对上,现场大神请解答..)
+  - `DealWeight` 和 `VerifiedDealWeight`的直接等于`SectorSize`
 
-- `storage market actor`
+- 接发单流程变化:
 
-  本来新的`FIL+`业务已经和它分离了,看起来和它不会再有任何关系, 但为了与当前的`client-market-provider`的工作模式保持一致.
-  所以,依然将 `storage market actor`作为中间的撮合层, 在其中完成了复杂的相关业务逻辑,外部看起来流程和之前保持一致. [流程描述](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0045.md#built-in-storage-market-as-a-delegate)大致如下:
-
-  1. `FIL+ clients`调用`stroage markets actor`发布订单, 设置订单参数`DealProposal.verified_deal`为`true`.
-  2. `market actor`的`publish_storage_deal`内部, 如果订单`verified_deal`为 true, 则调用`data cap token`的`Transfer`, 最终会在`verified registry actor`中创建一条`Allocation`的记录, 表示`data cap`配额已经分配给了`picee cid`代表的数据.
-  3. `SP`开始封装扇区, 在第一次`WinPoST`(如果是`snapup`只需要在`replica-update`)时, 就会在`verifyied rregistry actor`中创建一条`Claim, `记录`Allocation`被`SP`的某个扇区获取, `SP`获得`data cap`带来的算力增益效果.
-
-- 扇区[封装逻辑发生变化](https://github.com/filecoin-project/lotus/pull/9412)(venus cluster 有影响?)
+  - 通过`storage market actor`代理,继续沿用`vn16`中的的发单流程.
+      本来新的`FIL+`业务已经和它分离了,看起来和它不会再有任何关系, 但为了与当前的`client-market-provider`的工作模式保持一致. 
+      所以,依然将 `storage market actor`作为中间的撮合层, 在其中完成了复杂的相关业务逻辑,外部看起来流程和之前保持一致. [流程描述](https://github.com/filecoin-project/FIPs/blob/master/FIPS/fip-0045.md#built-in-storage-market-as-a-delegate)大致如下:
+      
+        1. `FIL+ clients`调用`stroage markets actor`发布订单, 设置订单参数`DealProposal.verified_deal`为`true`.
+        2. `market actor`的`publish_storage_deal`内部, 如果订单`verified_deal`为true, 则调用`data cap token`的`Transfer`, 最终会在`verified registry actor`中创建一条`Allocation`的记录, 表示`data cap`配额已经分配给了`picee cid`代表的数据.
+            `Allocation`有一个`life span`, 最小90天, 最大5年. 但在**实际**中,这个值会被自动按如下的逻辑进行设置.
+      
+      ```rust
+          pub const MINIMUM_VERIFIED_ALLOCATION_TERM: i64 = 180 * EPOCHS_IN_DAY;
+          pub const MAXIMUM_VERIFIED_ALLOCATION_TERM: i64 = 5 * EPOCHS_IN_YEAR;
+          pub const MAXIMUM_VERIFIED_ALLOCATION_EXPIRATION: i64 = 60 * EPOCHS_IN_DAY;
+          pub const MARKET_DEFAULT_ALLOCATION_TERM_BUFFER: i64 = 90 * EPOCHS_IN_DAY;
+          let alloc_term_min = deal.proposal.end_epoch - deal.proposal.start_epoch;
+          let alloc_term_max = min( alloc_term_min + policy.market_default_allocation_term_buffer, policy.maximum_verified_allocation_term,);
+          let alloc_expiration = min(deal.proposal.start_epoch, curr_epoch + policy.maximum_verified_allocation_expiration);
+    ```
+    
+      3. `SP`开始封装扇区, 在第一次`WinPoST`(如果是`snapup`只需要在`replica-update`)时, 就会在`verifyied rregistry actor`中创建一条`Claim, `记录`Allocation`被`SP`的某个扇区获取, `SP`获得`data cap`带来的算力增益效果.
+    
+  - 绕过`stroage market actor`使用新的发单流程(需待[架构调整](https://github.com/filecoin-project/FIPs/discussions/298)完成后), 在新的方案中, 对于扇区封装的`Piece`定义为:
+    ```go
+        type PieceManifest struct {
+          // Each piece may specify a FIL+ verified data cap allocation ID.
+          // If the piece is a sub-piece of a larger allocation, also specifies
+          // the range covered and an inclusion proof in the allocation.
+            VerifiedDataAllocationID uint64 // Optional
+            VerifiedDataRangeStart   uint64
+            VerifiedDataRangeEnd     uint64
+        }
+    ```
+    和`Allocation`建立了直接的关联, 所以,在计算sector获取的增强算力得以不再依赖`storage market`的deal. 新的流程大致如下:
+    1. Allocation，即发单，可以选择这个订单时长的一个区间。最短6个月，最长5年
+    2. 发单之日和发单中定义的SP完成封装的时间，不得大于60天
+    3. 一旦发单，`client`持有的`datacap token`会被转至一个`verified registry`
+    4. 当SP没有能够在`client`规定的高度前完成订单封装，`datacap token`会返还给`client`，即接单失败
+    5. 原有的f+治理的方式之一，移除`client`地址上的`datacap`功能，现变为能够实现把`client`地址持有的`datacap token`给烧掉
+    6. 当一个`SP`成功接单之后，一个`allocation`就转变为SP的一个`claim`；`verified registry`中保管的`datacap token`也因接单成功后，直接燃烧掉
+    7. 当一个SP的订单到期之后，`claim`被移除
+    8. SP可以延长`claim`，即延长订单，但不能超过发单时定义的订单最长生命
+    9. 同时，一个`client`可以花费`datacap token`给一个订单续期，但是订单生命周期最长不能超过5年
+  
+- 扇区[封装逻辑发生变化](https://github.com/filecoin-project/lotus/pull/9412)(venus cluster有影响?)
 
 - 扇区[续期逻辑发生变化](https://github.com/filecoin-project/lotus/issues/9369)(续期工具有影响?)
-
-- 扇区只要封装了带'data cap'的数据,无需走`storage market`的订单流程,就能自动获取`data cap`的收益?(待确认)
-  原文:
-
-  > The client and provider do not need to also do a deal via a storage market if the QA power rewards are sufficient compensation to the provider (e.g. for all zero-priced deals today). But they can do a deal too if the client wants to pay more.
 
 - 对于`venus`来说
 
@@ -92,31 +120,9 @@
     - `deal_proposal`类型中增加了`verified_deal`字段, `venus-market`, `venus-shared`中对应的自定义类型将发生变化
     - 还应当考虑由上一条引出的升级后`数据迁移`问题
 
-**`FIP45`的影响远不止上述提到的内容, 可以说其对于 filecoin 架构和生态的影响都非常的巨大.其影响会随着时间的推移逐步的体现出来.**
-
-**此提案的实现, 为存储市场更加开发的可编程性提供了更广阔的空间. 从软件的角度来说,filecoin 向`高内聚, 低耦合`更进了迈进了一步.**
-
 #### 市场解读
 
-FIP0045 的核心之一是`datacap token`化。为 fvm 能够更好的利用`datacap token`去实现一些用户自定义的场景。同时这给整个接单流程带来了巨大的变化。重点如下...
-
-FIP 定义的术语：
-
-- **Allocation**: DataCap allocated by a client to a specific piece of data.
-- **Claim**: a provider's assertion they are storing all or part of an allocation
-- **Term**: period of time for which a DataCap allocation or claim is valid or active.
-
-接发单流程变化：
-
-- Allocation，即发单，可以选择这个订单时长的一个区间。最短 6 个月，最长 5 年
-- 发单之日和发单中定义的 SP 完成封装的时间，不得大于 60 天
-- 一旦发单，`client`持有的`datacap token`会被转至一个`verified registry`
-- 当 SP 没有能够在`client`规定的高度前完成订单封装，`datacap token`会返还给`client`，即接单失败
-- 原有的 f+治理的方式之一，移除`client`地址上的`datacap`功能，现变为能够实现把`client`地址持有的`datacap token`给烧掉
-- 当一个`SP`成功接单之后，一个`allocation`就转变为 SP 的一个`claim`；`verified registry`中保管的`datacap token`也因接单成功后，直接燃烧掉
-- 当一个 SP 的订单到期之后，`claim`被移除
-- `client` 可以延长`claim`，但不能超过发单时定义的订单最长生命
-- 同时，一个`client`可以花费`datacap token`给一个订单续期，但是订单生命周期最长不能超过 5 年
+FIP0045的核心之一是`datacap token`化。为fvm能够更好的利用`datacap token`去实现一些用户自定义的场景。同时这给整个接单流程带来了巨大的变化。重点如下.
 
 关于`datacap token`：
 
@@ -140,6 +146,25 @@ SP 激励：
 - 可以预见的网络中的`client`将发送更多最大时长为 5 年的`datacap`订单以获取最大利益
 - SP 倾向 5 年订单，可能导致有实际短期需求的订单得不到存储
 - 可能短期发单`gas`会提高
+
+对于生态的考虑:
+
+> - Indefinitely-extended QA power over a long period could allow a provider to accumulate a large amount of consensus power relative to their storage commitment.
+>   - This is probably not an issue if many other providers also accumulate power through long-term storage of verified useful data. That’s probably healthy network behaviour.
+>   - The verified registry notaries could set a conservative maximum term for data cap allocations to limit term extension until we’re confident the behaviour is healthy.
+> - Data cap is too powerful if indefinite.
+>   - Each unit of data cap becomes less powerful with each incremental unit of data cap granted elsewhere. As verification procedures and automation improve, we might expect data cap to become increasingly abundant over time.
+>   - Verified registry limits could bound the long-term power initially.
+> - The network might end up carrying a bunch of data that’s not very useful.
+>   - In an environment of increasing abundance of storage capacity and/or demand, this should be a relatively minor concern. Eventually the subsidy earned by verified-but-not-useful data will fall below the opportunity cost of a paid-for storage deal; the situation can only last until the market-clearing price for a verified piece of data rises above zero.
+>   - Verified registry limits could bound the worst case, as we gain confidence
+> - Longer FIL+ terms reward early participants more than later ones.
+>   - This is true, but this reward to being early is usually seen as compensation for the risk of committing to a new network.
+>   - Abundant data cap will reward providers that commit to storing useful data even more than those who are early but less aligned.
+
+**`FIP45`的影响远不止上述提到的内容, 可以说其对于 filecoin 架构和生态的影响都非常的巨大.其影响会随着时间的推移逐步的体现出来.**
+
+**此提案的实现, 为存储市场更加开发的可编程性提供了更广阔的空间. 从软件的角度来说,filecoin 向`高内聚, 低耦合`更进了迈进了一步.**
 
 ### FIP34 Fix pre-commit deposit independent of sector content 解读
 


### PR DESCRIPTION
1. 将新老两种发单流程合并到一个章节中.
2. 将`data cap actor`统一改为`data cap token`.
3. 市场解读增加了一些对于生态的考虑的引用